### PR TITLE
Fix buffer.sequence for mmap

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1372,6 +1372,7 @@ static int vidioc_qbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 		else
 			b->buffer.timestamp = buf->timestamp;
 		b->buffer.bytesused = buf->bytesused;
+		b->buffer.sequence = dev->write_position;
 		set_done(b);
 		buffer_written(dev, b);
 


### PR DESCRIPTION
When using gstreamer for streaming frames into the loopback the sequence number on the v4l2 buffers read out of the loopback stays at zero.

When using FFMPEG instead to populate the loopback device the sequence number increases as expected.

The difference is that FFMPEG uses 'rw' ('write') while gstreamer uses 'mmap' ('qbuf'/'dqbuf').

And 'b->sequence' was currently only being set to 'dev->write_position' in 'v4l2_loopback_write()', but not in 'vidioc_qbuf()'.

See https://github.com/umlaeute/v4l2loopback/issues/466